### PR TITLE
chore: prefer use `require.resolve()` instead of ESLint auto-behavior

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+index.js

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 module.exports = {
   extends: [
-    'standard',
-    'plugin:prettier/recommended',
-    '@yproximite/base',
+    require.resolve('eslint-config-standard'),
+    require.resolve('eslint-config-prettier'),
+    require.resolve('@yproximite/eslint-config-base'),
+  ],
+  plugins: [
+    'prettier',
   ],
   globals: {
     jQuery: true,
     $: true,
+  },
+  rules: {
+    'prettier/prettier': 'error',
   },
 };


### PR DESCRIPTION
To prevent some possible errors